### PR TITLE
Render affiliations as separate paragraphs

### DIFF
--- a/_extensions/authors-block/from_author_info_blocks.lua
+++ b/_extensions/authors-block/from_author_info_blocks.lua
@@ -185,16 +185,15 @@ M.create_authors_inlines = create_authors_inlines
 -- taken from https://github.com/pandoc/lua-filters/blob/1660794b991c3553968beb993f5aabb99b317584/author-info-blocks/author-info-blocks.lua
 --- Generate a block list all affiliations, marked with arabic numbers.
 local function create_affiliations_blocks(affiliations)
-  local affil_lines = List:new(affiliations):map(
-    function (affil, i)
+  return List:new(affiliations):map(
+    function (affil)
       local num_inlines = List:new{
         pandoc.Superscript{pandoc.Str(affil.number)},
         pandoc.Space()
       }
-      return num_inlines .. affil.name
+      return pandoc.Para(num_inlines .. affil.name)
     end
   )
-  return {pandoc.Para(intercalate(affil_lines, {pandoc.LineBreak()}))}
 end
 M.create_affiliations_blocks = create_affiliations_blocks
 


### PR DESCRIPTION
## Summary

Update `create_affiliations_blocks()` to emit one `pandoc.Para` per affiliation instead of combining all affiliations into one paragraph separated by manual line breaks.

## Motivation

In DOCX output, affiliations can inherit a justified paragraph style. When multiple affiliations are separated by manual line breaks within one paragraph, Microsoft Word stretches the spacing on every line except the last.
<img width="434" height="211" alt="image" src="https://github.com/user-attachments/assets/8d12de93-91bd-4009-b3c8-08e83a894c31" />

Using separate paragraphs prevents this unwanted justification and represents each affiliation as an independent block.

<img width="435" height="229" alt="image" src="https://github.com/user-attachments/assets/81ed3377-f0bd-48f2-b1bf-8df555f4b3c3" />

## Validation

- Rendered `example.qmd` to DOCX with Quarto 1.9.38.
- Confirmed that each affiliation appears in a separate Word paragraph.
- Confirmed that no manual line breaks remain between affiliations.
- Confirmed that superscript numbering and affiliation text are preserved.

## Note

Vertical spacing between affiliations follows the paragraph style in the reference DOCX and can therefore be customized through that document.